### PR TITLE
Replaced Treatment and Transplant queries w DxStg and Hospital

### DIFF
--- a/CNExT/cnext_procedure_occurrence.sql
+++ b/CNExT/cnext_procedure_occurrence.sql
@@ -48,36 +48,40 @@ LTV - 2/22/2022 - Changed condition on the Radiation table. Added WHERE F05257 >
 */
 SET NOCOUNT ON;
 SELECT 'IDENTITY_CONTEXT|SOURCE_PK|PROCEDURE_OCCURRENCE_ID|PERSON_ID|PROCEDURE_CONCEPT_ID|PROCEDURE_DATE|PROCEDURE_DATETIME|PROCEDURE_TYPE_CONCEPT_ID|MODIFIER_CONCEPT_ID|QUANTITY|PROVIDER_ID|VISIT_OCCURRENCE_ID|VISIT_DETAIL_ID|PROCEDURE_SOURCE_VALUE|PROCEDURE_SOURCE_CONCEPT_ID|MODIFIER_SOURCE_VALUE|MRN|CONDITION_CONCEPT_ID_SITE|Modified_DtTm';
-SELECT  'CNEXT TREATMENT(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT                                                                           /*'UNMTR DX/STG RECORD'*/
-         ,rsSource.uk  AS SOURCE_PK
-         ,rsSource.uk AS PROCEDURE_OCCURRENCE_ID
-         ,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
-         ,'740@'  + TRT.F00420 AS PROCEDURE_CONCEPT_ID
+SELECT  'CNEXT DIAGNOSIS/STAGE(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT                                                                           /*'UNMTR DX/STG RECORD'*/
+         ,concat('DXS-', DXS.uk) AS SOURCE_PK
+         ,concat('DXS-', DXS.uk) AS PROCEDURE_OCCURRENCE_ID
+         ,PAT.uk AS PERSON_ID
+         ,CASE
+			WHEN DXS.F05084 <> '' 
+			THEN '740@' + DXS.F05084
+            ELSE ''
+          END AS PROCEDURE_CONCEPT_ID
          ,case
-		     when F00422 = '99999999'
+		     when DXS.F05175 = '99999999'
 		     then ''
-		     when right(F00422, 4) = '9999'
-		     then FORMAT(TRY_CAST(left(F00422,4) + '0101' AS DATE), 'yyyy-MM-dd HH:mm:ss')
-		     when right(F00422,2) = '99'
-             then FORMAT(TRY_CAST(left(F00422,6) + '01' AS DATE), 'yyyy-MM-dd HH:mm:ss')
-		     else ISNULL(FORMAT(TRY_CAST(F00422 AS DATE), 'yyyy-MM-dd HH:mm:ss'), '')
+		     when right(DXS.F05175, 4) = '9999'
+		     then FORMAT(TRY_CAST(left(DXS.F05175,4) + '0101' AS DATE), 'yyyy-MM-dd HH:mm:ss')
+		     when right(DXS.F05175,2) = '99'
+             then FORMAT(TRY_CAST(left(DXS.F05175,6) + '01' AS DATE), 'yyyy-MM-dd HH:mm:ss')
+		     else ISNULL(FORMAT(TRY_CAST(DXS.F05175 AS DATE), 'yyyy-MM-dd HH:mm:ss'), '')
 		    END AS PROCEDURE_DATE 
          ,case
-		     when F00422 = '99999999'
+		     when DXS.F05175 = '99999999'
 		     then ''
-		     when right(F00422, 4) = '9999'
-		     then FORMAT(TRY_CAST(left(F00422,4) + '0101' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
-		     when right(F00422,2) = '99'
-             then FORMAT(TRY_CAST(left(F00422,6) + '01' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
-		     else ISNULL(FORMAT(TRY_CAST(F00422 AS DATETIME),'yyyy-MM-dd HH:mm:ss'), '')
+		     when right(DXS.F05175, 4) = '9999'
+		     then FORMAT(TRY_CAST(left(DXS.F05175,4) + '0101' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
+		     when right(DXS.F05175,2) = '99'
+             then FORMAT(TRY_CAST(left(DXS.F05175,6) + '01' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
+		     else ISNULL(FORMAT(TRY_CAST(DXS.F05175 AS DATETIME),'yyyy-MM-dd HH:mm:ss'), '')
 		    END AS PROCEDURE_DATETIME
     	 ,'1791@32' AS PROCEDURE_TYPE_CONCEPT_ID
          ,0 AS MODIFIER_CONCEPT_ID
          ,1 AS QUANTITY
-         ,(SELECT TOP 1 ISNULL(rsTarget.F05162, '') FROM UNM_CNExTCases.dbo.DxStg rsTarget WHERE rsSource.uk = rsTarget.fk2 Order By rsTarget.UK ASC) AS PROVIDER_ID     /*2460*/
+         ,ISNULL(DXS.F05162, '') AS PROVIDER_ID
          ,rsSource.uk AS VISIT_OCCURRENCE_ID
-         ,rsSource.uk AS VISIT_DETAIL_ID
-         ,TRT.F00420 AS PROCEDURE_SOURCE_VALUE
+         ,concat('DXS-', DXS.uk) AS VISIT_DETAIL_ID
+         ,DXS.F05084 AS PROCEDURE_SOURCE_VALUE
          ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
          ,0 AS MODIFIER_SOURCE_VALUE
 		 ,ISNULL(HSP.F00006, '') AS MRN
@@ -87,17 +91,19 @@ SELECT  'CNEXT TREATMENT(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT        
 	else format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss') end
 	AS modified_dtTm
   FROM UNM_CNExTCases.dbo.Tumor rsSource
-  JOIN UNM_CNExTCases.dbo.Treatment TRT on TRT.UK = rsSource.UK  --TRT.fk1 = rsSource.UK
+  JOIN UNM_CNExTCases.dbo.DxStg DXS on DXS.fk2 = rsSource.uk
+  JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
   JOIN UNM_CNExTCases.dbo.Hospital HSP on HSP.FK2 = rsSource.UK
   JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
- where TRT.F00420 NOT IN ('00','09')
+ where DXS.F05084 NOT IN ('00','09')
    and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
    and HSP.F00006 >= 1000
+   and DXS.F05175 != '00000000'
 UNION
 SELECT 'CNEXT SURG(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT                                                                   /*'UNMTR SURGICAL RECORD'*/
-        ,rsSource.uk AS SOURCE_PK
-        ,rsSource.UK AS PROCEDURE_OCCURRENCE_ID
-        ,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
+        ,concat('SRG-', SRG.uk) AS SOURCE_PK
+        ,concat('SRG-', SRG.uk) AS PROCEDURE_OCCURRENCE_ID
+        ,PAT.uk AS PERSON_ID
         ,CASE                                  --no nulls, but empty space values to handle
 			WHEN SRG.F03488 <> ''
 			THEN '1290@'  + SRG.F03488
@@ -126,8 +132,8 @@ SELECT 'CNEXT SURG(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT              
 		,1 AS QUANTITY
     	,ISNULL(SRG.F05161, '') AS PROVIDER_ID                                            /*2480*/
         ,rsSource.uk AS VISIT_OCCURRENCE_ID
-        ,rsSource.uk AS VISIT_DETAIL_ID
-        ,SRG.F03488 AS PROCEDURE_SOURCE_VALUE    --nulls handled by predicate             /*740*/
+        ,concat('SRG-', SRG.uk) AS VISIT_DETAIL_ID
+        ,SRG.F03488 AS PROCEDURE_SOURCE_VALUE
 	    ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE
 		,ISNULL(HSP.F00006, '') AS MRN
@@ -139,6 +145,7 @@ SELECT 'CNEXT SURG(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT              
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
    JOIN UNM_CNExTCases.dbo.Surg SRG ON SRG.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
    JOIN UNM_CNExTCases.dbo.Hospital HSP ON HSP.fk2 = rsSource.uk
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
   WHERE SRG.F03488 > '00' 
@@ -149,9 +156,9 @@ SELECT 'CNEXT SURG(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT              
     AND HSP.F00006 >= 1000
 UNION
 SELECT 'CNEXT RADIATION(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT                                                                  /*'UNMTR RADIATION RECORD'*/
-        ,rsSource.uk AS SOURCE_PK
-        ,rsSource.UK AS PROCEDURE_OCCURRENCE_ID
-        ,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
+        ,concat('RAD-', RAD.uk) AS SOURCE_PK
+        ,concat('RAD-', RAD.uk) AS PROCEDURE_OCCURRENCE_ID
+        ,PAT.uk AS PERSON_ID
        	,'1506@'  + RAD.F07799 AS PROCEDURE_CONCEPT_ID
 		,case
 		     when RAD.F05187 = '99999999'
@@ -176,7 +183,7 @@ SELECT 'CNEXT RADIATION(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT         
 		,1 AS QUANTITY
     	,ISNULL(RAD.F05156, '') AS PROVIDER_ID                                             /*2480*/
         ,rsSource.uk AS VISIT_OCCURRENCE_ID
-        ,rsSource.uk AS VISIT_DETAIL_ID
+        ,concat('RAD-', RAD.uk) AS VISIT_DETAIL_ID
         ,RAD.F07799 AS PROCEDURE_SOURCE_VALUE    --nulls handled by predicate              /*740*/
 	    ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE
@@ -188,21 +195,22 @@ SELECT 'CNEXT RADIATION(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT         
 	        else format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss')
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
-  INNER JOIN UNM_CNExTCases.dbo.Radiation RAD ON RAD.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Radiation RAD ON RAD.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
    JOIN UNM_CNExTCases.dbo.Hospital HSP ON HSP.fk2 = rsSource.uk
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
-  WHERE F05257 > '000' 
-    AND F07799 > '00'
-    AND F07799 < '99'
+  WHERE RAD.F05257 > '000' 
+    AND RAD.F07799 > '00'
+    AND RAD.F07799 < '99'
 	and ((RAD.F05187 is not NULL and RAD.F05187 != '' and RAD.F05187 not in ('00000000','88888888'))
 	 or (RAD.F05212 is not NULL and RAD.F05212 != '' and RAD.F05212 not in ('00000000','88888888')))
 	and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
     and HSP.F00006 >= 1000
 UNION
 SELECT 'CNEXT OTHER(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT                                                                 /*'UNMTR OTHER RECORD'*/
-        ,rsSource.uk SOURCE_PK
-        ,rsSource.UK AS PROCEDURE_OCCURRENCE_ID
-        ,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
+        ,concat('OTH-', OTH.uk) SOURCE_PK
+        ,concat('OTH-', OTH.uk) AS PROCEDURE_OCCURRENCE_ID
+        ,PAT.uk AS PERSON_ID
         ,'730@'  + OTH.F05069 AS PROCEDURE_CONCEPT_ID
 		,case
 		     when OTH.F05195 = '99999999'
@@ -227,7 +235,7 @@ SELECT 'CNEXT OTHER(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT             
 		,1 AS QUANTITY
     	,ISNULL(OTH.F05160, '') AS PROVIDER_ID                                      /*2460*/
         ,rsSource.uk AS VISIT_OCCURRENCE_ID
-        ,rsSource.uk AS VISIT_DETAIL_ID
+        ,concat('OTH-', OTH.uk) AS VISIT_DETAIL_ID
         ,OTH.F05069 AS PROCEDURE_SOURCE_VALUE   --nulls handled by predicate        /*740*/
 	    ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE
@@ -240,6 +248,7 @@ SELECT 'CNEXT OTHER(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT             
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
    JOIN UNM_CNExTCases.dbo.Other OTH ON OTH.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
    JOIN UNM_CNExTCases.dbo.Hospital HSP ON HSP.fk2 = rsSource.uk
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
   WHERE OTH.F05069 in ( '1','2','3','6')
@@ -248,9 +257,9 @@ SELECT 'CNEXT OTHER(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT             
     and HSP.F00006 >= 1000
 UNION
 SELECT 'CNEXT CHEMO(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
-        ,rsSource.uk AS SOURCE_PK
-        ,rsSource.uk AS PROCEDURE_OCCURRENCE_ID
-    	,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
+        ,concat('CHM-', CHM.uk) AS SOURCE_PK
+        ,concat('CHM-', CHM.uk) AS PROCEDURE_OCCURRENCE_ID
+    	,PAT.uk AS PERSON_ID
     	,'700@' + CHM.F05037 AS PROCEDURE_CONCEPT_ID
 	    ,case
 		     when CHM.F05189 = '99999999'
@@ -275,7 +284,7 @@ SELECT 'CNEXT CHEMO(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 		,1 AS QUANTITY
     	,ISNULL(CHM.F05157, '') AS PROVIDER_ID 
 		,rsSource.uk AS VISIT_OCCURRENCE_ID
-        ,rsSource.uk AS VISIT_DETAIL_ID		
+        ,concat('CHM-', CHM.uk) AS VISIT_DETAIL_ID		
         ,CHM.F05037 AS PROCEDURE_SOURCE_VALUE
         ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE
@@ -287,8 +296,9 @@ SELECT 'CNEXT CHEMO(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 	        else format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss')
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
-   JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2
    JOIN UNM_CNExTCases.dbo.Chemo CHM ON CHM.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
+   JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
 WHERE CHM.F05037 IN ('01', '02', '03')
     AND CHM.F05669 > '00'
@@ -298,9 +308,9 @@ WHERE CHM.F05037 IN ('01', '02', '03')
     and HSP.F00006 >= 1000
 UNION
 SELECT 'CNEXT HORMONE(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
-        ,rsSource.uk AS SOURCE_PK
-        ,rsSource.uk AS PROCEDURE_OCCURRENCE_ID
-    	,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
+        ,concat('HOR-', HOR.uk) AS SOURCE_PK
+        ,concat('HOR-', HOR.uk) AS PROCEDURE_OCCURRENCE_ID
+    	,PAT.uk AS PERSON_ID
     	,'710@' + HOR.F05063 AS PROCEDURE_CONCEPT_ID
 	    ,case
 		     when HOR.F05191 = '99999999'
@@ -325,7 +335,7 @@ SELECT 'CNEXT HORMONE(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 		,1 AS QUANTITY
     	,ISNULL(HOR.F05158, '') AS PROVIDER_ID
 		,rsSource.uk AS VISIT_OCCURRENCE_ID
-	    ,rsSource.uk AS VISIT_DETAIL_ID		
+	    ,concat('HOR-', HOR.uk) AS VISIT_DETAIL_ID		
         ,HOR.F05063 AS PROCEDURE_SOURCE_VALUE
         ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE
@@ -337,8 +347,9 @@ SELECT 'CNEXT HORMONE(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 	        else format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss')
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
-   JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2
    JOIN UNM_CNExTCases.dbo.Hormone HOR ON HOR.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
+   JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2   
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
 WHERE HOR.F05063 = '01'
   and ((HOR.F05191 is not null and HOR.F05191 != '' and HOR.F05191 not in ('00000000','88888888'))
@@ -347,9 +358,9 @@ WHERE HOR.F05063 = '01'
   and HSP.F00006 >= 1000
 UNION
 SELECT 'CNEXT IMMUNO(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
-        ,rsSource.uk AS SOURCE_PK
-        ,rsSource.uk AS VISIT_DETAIL_ID
-    	,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
+        ,concat('BRM-', BRM.uk) AS SOURCE_PK
+        ,concat('BRM-', BRM.uk) AS PROCEDURE_OCCURRENCE_ID
+    	,PAT.uk AS PERSON_ID
 		,'720@' + BRM.F05066  AS PROCEDURE_CONCEPT_ID
 	    ,case
 		     when BRM.F05193 = '99999999'
@@ -374,7 +385,7 @@ SELECT 'CNEXT IMMUNO(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 		,1 AS QUANTITY
     	,ISNULL(BRM.F05159, '') AS PROVIDER_ID
 		,rsSource.uk AS VISIT_OCCURRENCE_ID
-	    ,rsSource.uk AS VISIT_DETAIL_ID		
+	    ,concat('BRM-', BRM.uk) AS VISIT_DETAIL_ID		
     	,BRM.F05066 AS PROCEDURE_SOURCE_VALUE
         ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE	
@@ -386,8 +397,9 @@ SELECT 'CNEXT IMMUNO(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 	        else format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss')
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
-   JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2
    JOIN UNM_CNExTCases.dbo.Immuno BRM ON BRM.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
+   JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
 WHERE BRM.F05066 = '01'
   and ((BRM.F05193 is not null and BRM.F05193 != '' and BRM.F05193 not in('00000000','88888888'))
@@ -395,36 +407,36 @@ WHERE BRM.F05066 = '01'
   and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
   and HSP.F00006 >= 1000
 UNION
-SELECT 'CNEXT TRANSPLANT(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
-        ,rsSource.uk AS SOURCE_PK
-        ,rsSource.uk AS VISIT_DETAIL_ID
-    	,(SELECT rsTarget.UK FROM UNM_CNExTCases.dbo.Patient rsTarget WHERE rsTarget.uk =  rsSource.fk1) AS PERSON_ID
-		,'3250@' + TRE.F05086  AS PROCEDURE_CONCEPT_ID
+SELECT 'CNEXT HOSP(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
+        ,concat('HSP-', HSP.uk) AS SOURCE_PK
+        ,concat('HSP-', HSP.uk) AS PROCEDURE_OCCURRENCE_ID
+    	,PAT.uk AS PERSON_ID
+		,ISNULL(HSG.F05522, '') AS PROCEDURE_CONCEPT_ID
 	    ,case
-		     when TRE.F05209 = '99999999'
-		     then ''
-		     when right(TRE.F05209, 4) = '9999'
-		     then FORMAT(TRY_CAST(left(TRE.F05209,4) + '0101' AS DATE), 'yyyy-MM-dd HH:mm:ss')
-		     when right(TRE.F05209,2) = '99'
-             then FORMAT(TRY_CAST(left(TRE.F05209,6) + '01' AS DATE), 'yyyy-MM-dd HH:mm:ss')
-		     else ISNULL(FORMAT(TRY_CAST(TRE.F05209 AS DATE), 'yyyy-MM-dd HH:mm:ss'), '')
-		  END AS PROCEDURE_DATE
-		  ,case
-		     when TRE.F05209 = '99999999'
-		     then ''
-		     when right(TRE.F05209, 4) = '9999'
-		     then FORMAT(TRY_CAST(left(TRE.F05209,4) + '0101' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
-		     when right(TRE.F05209,2) = '99'
-             then FORMAT(TRY_CAST(left(TRE.F05209,6) + '01' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
-		     else ISNULL(FORMAT(TRY_CAST(TRE.F05209 AS DATETIME), 'yyyy-MM-dd HH:mm:ss'), '')
-		  END AS PROCEDURE_DATETIME 
+		    when HExt.F00427 = '99999999'
+		    then ''
+		    when right(HExt.F00427,4) = '9999'
+		    then ISNULL(FORMAT(TRY_CAST(left(HExt.F00427,4) + '0101' AS DATE), 'yyyy-MM-dd HH:mm:ss'), '') 
+		    when right(HExt.F00427,2) = '99'
+		    then ISNULL(FORMAT(TRY_CAST(left(HExt.F00427,6) + '01' AS DATE), 'yyyy-MM-dd HH:mm:ss'), '')
+		    else ISNULL(FORMAT(TRY_CAST(HExt.F00427 AS DATE), 'yyyy-MM-dd HH:mm:ss'), '')
+	      end AS PROCEDURE_DATE
+		,case
+		    when HExt.F00427 = '99999999'
+		    then ''
+		    when right(HExt.F00427,4) = '9999'
+		    then ISNULL(FORMAT(TRY_CAST(left(HExt.F00427,4) + '0101' AS DATETIME), 'yyyy-MM-dd HH:mm:ss'), '') 
+		    when right(HExt.F00427,2) = '99'
+		    then ISNULL(FORMAT(TRY_CAST(left(HExt.F00427,6) + '01' AS DATETIME), 'yyyy-MM-dd HH:mm:ss'), '')
+		    else ISNULL(FORMAT(TRY_CAST(HExt.F00427 AS DATETIME), 'yyyy-MM-dd HH:mm:ss'), '')
+	     end ASPROCEDURE_DATETIME 
         ,'1791@32' AS PROCEDURE_TYPE_CONCEPT_ID
 		,0 AS MODIFIER_CONCEPT_ID
 		,1 AS QUANTITY
-    	,ISNULL(TRE.F06134, '') AS PROVIDER_ID
+    	,ISNULL(HExt.F00675, '') AS PROVIDER_ID
 		,rsSource.uk AS VISIT_OCCURRENCE_ID
-	    ,rsSource.uk AS VISIT_DETAIL_ID		
-    	,TRE.F05086 AS PROCEDURE_SOURCE_VALUE
+	    ,concat('HSP-', HSP.uk) AS VISIT_DETAIL_ID		
+    	,ISNULL(HExt.F03564, '') AS PROCEDURE_SOURCE_VALUE
         ,0 AS PROCEDURE_SOURCE_CONCEPT_ID
 	    ,0 AS MODIFIER_SOURCE_VALUE	
 	    ,ISNULL(HSP.F00006, '') AS MRN
@@ -436,8 +448,10 @@ SELECT 'CNEXT TRANSPLANT(OMOP_PROCEDURE_OCCURRENCE)' AS IDENTITY_CONTEXT
 		 end AS modified_dtTm
    FROM UNM_CNExTCases.dbo.Tumor rsSource
    JOIN UNM_CNExTCases.dbo.Hospital HSP ON rsSource.uk = HSP.fk2
-   JOIN UNM_CNExTCases.dbo.Transplant TRE ON TRE.fk2 = rsSource.uk
+   JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
+   JOIN UNM_CNExTCases.dbo.HospSupp HSG ON HSG.UK = HSP.UK
    JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
-WHERE TRE.F05086 in('10', '11', '12', '20', '30', '40')
-  and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
-  and HSP.F00006 >= 1000
+  WHERE ((HExt.F00427 is not null and HExt.F00427 != '' and HExt.F00427 not in ('00000000','88888888'))
+     or (HExt.F00128 is not null and HExt.F00128 != '' and HExt.F00128 not in('00000000','88888888')))
+    and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
+    and HSP.F00006 >= 1000 

--- a/CNExT/cnext_visit_detail.sql
+++ b/CNExT/cnext_visit_detail.sql
@@ -541,4 +541,58 @@ UNION
 WHERE ((HExt.F00427 is not null and HExt.F00427 != '' and HExt.F00427 not in ('00000000','88888888'))
    or (HExt.F00128 is not null and HExt.F00128 != '' and HExt.F00128 not in('00000000','88888888')))
   and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
-  and HSP.F00006 >= 1000 
+  and HSP.F00006 >= 1000
+UNION
+SELECT 'CNEXT DIAGNOSIS/STAGE(OMOP_VISIT_DETAIL)' AS IDENTITY_CONTEXT
+         ,concat('DXS-', DXS.uk) AS SOURCE_PK
+         ,concat('DXS-', DXS.uk) AS VISIT_DETAIL_ID
+         ,PAT.uk AS PERSON_ID
+		 ,ISNULL(HSG.F05522, '') AS VISIT_DETAIL_CONCEPT_ID
+         ,case
+		     when DXS.F05175 = '99999999'
+		     then ''
+		     when right(DXS.F05175, 4) = '9999'
+		     then FORMAT(TRY_CAST(left(DXS.F05175,4) + '0101' AS DATE), 'yyyy-MM-dd HH:mm:ss')
+		     when right(DXS.F05175,2) = '99'
+             then FORMAT(TRY_CAST(left(DXS.F05175,6) + '01' AS DATE), 'yyyy-MM-dd HH:mm:ss')
+		     else ISNULL(FORMAT(TRY_CAST(DXS.F05175 AS DATE), 'yyyy-MM-dd HH:mm:ss'), '')
+		    END AS VISIT_DETAIL_START_DATE 
+         ,case
+		     when DXS.F05175 = '99999999'
+		     then ''
+		     when right(DXS.F05175, 4) = '9999'
+		     then FORMAT(TRY_CAST(left(DXS.F05175,4) + '0101' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
+		     when right(DXS.F05175,2) = '99'
+             then FORMAT(TRY_CAST(left(DXS.F05175,6) + '01' AS DATETIME), 'yyyy-MM-dd HH:mm:ss')
+		     else ISNULL(FORMAT(TRY_CAST(DXS.F05175 AS DATETIME),'yyyy-MM-dd HH:mm:ss'), '')
+		    END AS VISIT_DETAIL_START_DATETIME
+		 ,'' VISIT_DETAIL_END_DATE
+		 ,'' VISIT_DETAIL_END_DATETIME
+    	 ,'1791@32' AS VISIT_DETAIL_TYPE_CONCEPT_ID
+		 ,ISNULL(DXS.F05162, '') AS PROVIDER_ID
+         ,ISNULL(DXS.F05083, '') AS CARE_SITE_ID
+         ,DXS.F05084 AS VISIT_DETAIL_SOURCE_VALUE
+	    ,'740@' + DXS.F05084 AS VISIT_DETAIL_SOURCE_CONCEPT_ID
+		,ISNULL(HExt.F01684, '') AS ADMITTING_SOURCE_VALUE
+	    ,ISNULL(HExt.F03715, '') AS ADMITTING_SOURCE_CONCEPT_ID
+	    ,ISNULL(HExt.F01685, '') AS DISCHARGE_TO_SOURCE_VALUE
+	    ,ISNULL(HExt.F03716, '') AS DISCHARGE_TO_CONCEPT_ID
+		,ISNULL(HSP.fk2, '') AS PRECEDING_VISIT_DETAIL_ID		
+		,'' AS VISIT_DETAIL_PARENT_ID
+	    ,rsSource.UK AS VISIT_OCCURRENCE_ID                               /*10*/
+		,ISNULL(HSP.F00006, '') AS MRN
+		,ISNULL(STUFF(rsSource.F00152,4,0,'.'), '') AS CONDITION_CONCEPT_ID_SITE
+   	    ,CASE
+    		WHEN format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss') is NULL
+            then format(GETDATE(), 'yyyy-MM-dd HH:mm:ss')  
+	        else format(TRY_CAST(HExt.F00084 as datetime),'yyyy-MM-dd HH:mm:ss')
+		 end AS modified_dtTm
+  FROM UNM_CNExTCases.dbo.Tumor rsSource
+  JOIN UNM_CNExTCases.dbo.DxStg DXS on DXS.fk2 = rsSource.uk
+  JOIN UNM_CNExTCases.dbo.Patient PAT on PAT.uk = rsSource.fk1
+  JOIN UNM_CNExTCases.dbo.Hospital HSP on HSP.FK2 = rsSource.UK
+  JOIN UNM_CNExTCases.dbo.HospExtended HExt on HSP.UK = HExt.UK
+ where DXS.F05084 NOT IN ('00','09')
+   and HSP.F00006 not in (999999998, 9999998, 999999, 9999)
+   and HSP.F00006 >= 1000
+   and DXS.F05175 != '00000000'  


### PR DESCRIPTION
Removed Treatment table query - replaced with DxStg table query. Removed Transplant table query - replaced with Hospital table query. Changed all select statements to pull SOURCE_PK, PROCEDURE_OCCURRENCE_ID, and VISIT_DETAIL_ID from the queried treatment table. Concatenated the treatment table's 3 letter code plus a dash to the treatment table's UK for each of these fields.